### PR TITLE
Use paintMask layer in Double raycasting

### DIFF
--- a/Scripts/PrefabPainter.cs
+++ b/Scripts/PrefabPainter.cs
@@ -579,13 +579,14 @@ namespace PrefabPainter
             obj.SetActive(false);
             RaycastHit groundHit;
 
-            if (Physics.Raycast(position, -obj.transform.up, out groundHit))
+            if (Physics.Raycast(position, -obj.transform.up, out groundHit, Mathf.Infinity, paintMask))
             {
                 RaycastHit objectHit;
                 if (LayerContain(paintMask, groundHit.collider.gameObject.layer))
                 {
                     obj.SetActive(true);
-                    if (Physics.Raycast(groundHit.point, obj.transform.up, out objectHit) &&
+
+                    if (Physics.Raycast(groundHit.point, obj.transform.up, out objectHit, Mathf.Infinity, paintMask) &&
                         obj.layer == objectHit.collider.gameObject.layer)
                     {
                         Vector3 newPos;

--- a/Scripts/PrefabPainter.cs
+++ b/Scripts/PrefabPainter.cs
@@ -586,7 +586,8 @@ namespace PrefabPainter
                 {
                     obj.SetActive(true);
 
-                    if (Physics.Raycast(groundHit.point, obj.transform.up, out objectHit, Mathf.Infinity, paintMask) &&
+                    int objMask = 1 << obj.layer;
+                    if (Physics.Raycast(groundHit.point, obj.transform.up, out objectHit, Mathf.Infinity, objMask) &&
                         obj.layer == objectHit.collider.gameObject.layer)
                     {
                         Vector3 newPos;


### PR DESCRIPTION
Code casts ray from up towards the mesh being painted one.
Hovewer this raycast not using paintMask could collide with some
colliders in between.

Example use-case is painting on the bottom of the lake and rays colliding
with water plane. Or perhaps painting prefabs inside a building with a roof.